### PR TITLE
Add versions without --enable-shared for ruby <= 2.3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -169,18 +169,14 @@ jobs:
       id: info
       run: |
         tag=enable-shared
+        suffix=''
+        if [ "${{ matrix.shared }}" == "0" ]; then suffix="_noshared"; fi
+        filename="ruby-${{ matrix.ruby-version}}$suffix-${{ matrix.os }}.tar.gz"
+        echo "::set-output name=filename::$filename"
         echo "::set-output name=tag::$tag"
 
-    - name: Set result filename
-      id: result
-      run: |
-        suffix=''
-        if [ "${{ matrix.shared }}" == "0" ]; then suffix="noshared"; fi
-        fname="ruby-${{ matrix.ruby-version}}_$suffix-${{ matrix.os }}.tar.gz"
-        echo "::set-output name=filename::$fname"
-
     - name: Check if already built
-      run: '! curl -s --head --fail https://github.com/ruby/ruby-builder/releases/download/${{ steps.info.outputs.tag }}/${{ steps.result.outputs.filename }}'
+      run: '! curl -s --head --fail https://github.com/ruby/ruby-builder/releases/download/${{ steps.info.outputs.tag }}/${{ steps.info.outputs.filename }}'
 
     - name: Clone ruby-build
       run: git clone --branch ruby23-openssl-linux https://github.com/eregon/ruby-build.git
@@ -206,7 +202,7 @@ jobs:
         RUBY_CONFIGURE_OPTS: --disable-install-doc
         CPPFLAGS: "-DENABLE_PATH_CHECK=0" # https://github.com/actions/virtual-environments/issues/267
     - name: Create archive
-      run: tar czf ${{ steps.result.outputs.filename }} -C ~/.rubies ruby-${{ matrix.ruby-version }}
+      run: tar czf ${{ steps.info.outputs.filename }} -C ~/.rubies ruby-${{ matrix.ruby-version }}
     - name: Install Bundler if needed
       run: |
         if [ ! -e ~/.rubies/ruby-${{ matrix.ruby-version }}/bin/bundle ]; then
@@ -230,8 +226,8 @@ jobs:
       with:
         # curl -s "https://api.github.com/repos/ruby/ruby-builder/releases/tags/$TAG" | jq -r .upload_url
         upload_url: 'https://uploads.github.com/repos/ruby/ruby-builder/releases/25022539/assets{?name,label}'
-        asset_path: ${{ steps.result.outputs.filename }}
-        asset_name: ${{ steps.result.outputs.filename }}
+        asset_path: ${{ steps.info.outputs.filename }}
+        asset_name: ${{ steps.info.outputs.filename }}
         asset_content_type: application/gzip
 
   buildRubinius:


### PR DESCRIPTION
This PR adds builds without `--enable-shared ` for rubies <= 2.3. Those will have `_noshared` suffix after version in the release filename (for example `ruby-2.3.1_noshared-ubuntu-18.04.tar.gz`).

Builds with `--enable-shared` are left as they are.

Idea is that in https://github.com/ruby/setup-ruby we could request `_noshared` suffixed version if needed (or add a separate action input there to do so).

<hr/>

Why this is required:

When trying to use gems with native extensions which are linked with openssl 1.1 this `--enable-shared` old ruby will segfault as the ruby itself loads openssl 1.0 and the gems (like `mysql2` or `rugged`) load system installed openssl 1.1  (or more precisely, libraries like `libmysqclient` or `libgit2` which those gems are wrapping are doing so).

Sample segfault when trying to use shared ruby 2.3.8 and mysql2 gem (wraps libmysqlient) in github action:
```
-- C level backtrace information -------------------------------------------
/home/runner/.rubies/ruby-2.3.8/lib/libruby.so.2.3(rb_vm_bugreport+0x974) [0x7efe783764c4] vm_dump.c:724
/home/runner/.rubies/ruby-2.3.8/lib/libruby.so.2.3(rb_bug_context+0xd4) [0x7efe781fda74] error.c:435
/home/runner/.rubies/ruby-2.3.8/lib/libruby.so.2.3(sigsegv+0x3e) [0x7efe782e150e] signal.c:890
/lib/x86_64-linux-gnu/libc.so.6 [0x7efe77dcdf20]
/lib/x86_64-linux-gnu/libc.so.6 [0x7efe77e38e8a]
/home/runner/.rubies/ruby-2.3.8/openssl/lib/libcrypto.so.1.0.0(lh_insert+0x10d) [0x7efe7542a6cd]
/home/runner/.rubies/ruby-2.3.8/openssl/lib/libcrypto.so.1.0.0(OBJ_NAME_add+0x6b) [0x7efe7537068b]
/usr/lib/x86_64-linux-gnu/libssl.so.1.1 [0x7efe7378613e]
/lib/x86_64-linux-gnu/libpthread.so.0(__pthread_once_slow+0xb7) [0x7efe77b7f827]
/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1(CRYPTO_THREAD_run_once+0x9) [0x7efe73462039]
/usr/lib/x86_64-linux-gnu/libssl.so.1.1(OPENSSL_init_ssl+0x67) [0x7efe73786337]
/usr/lib/x86_64-linux-gnu/libmysqlclient.so.20 [0x7efe73a3b754]
/usr/lib/x86_64-linux-gnu/libmysqlclient.so.20(mysql_server_init+0x67) [0x7efe73a00c27]
```

Note that at some point calls jump from system `libcrypto.so.1.1` into ruby bundled `libcrypto.so.1.0`.

The same thing happens when trying to call rugged gem, which wraps libgit2. This makes such ruby builds useless when testing some projects.

This problem is not an issue with rubies >= 2.4, as those are built with openssl 1.1 around.

Having noshared build for ruby 2.3 helps as there will be no `.so` files around for openssl1.0 as it will be statically linked into the ruby.