### PR TITLE
create-pr-to-setup-ruby action.yml: Use actions/checkout v6

### DIFF
--- a/.github/actions/create-pr-to-setup-ruby/action.yml
+++ b/.github/actions/create-pr-to-setup-ruby/action.yml
@@ -14,7 +14,7 @@ runs:
   using: "composite"
   steps:
     - name: Clone setup-ruby
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         repository: ruby/setup-ruby
         fetch-depth: 0


### PR DESCRIPTION
This avoids deprecation warnings.